### PR TITLE
omegaconf 2.3.0 ❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 channels:
     - https://staging.continuum.io/prefect/fs/pytest-lazy-fixture-feedstock/pr2/3c79d60
+
+upload_channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+    - https://staging.continuum.io/prefect/fs/pytest-lazy-fixture-feedstock/pr2/3c79d60

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
-channels:
-    - https://staging.continuum.io/prefect/fs/pytest-lazy-fixture-feedstock/pr2/3c79d60
-
 upload_channels:
   - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
     #
     # antlr is included as binary in build_helpers/bin/antlr-4.9.3-complete.jar
     # also for this reason and the next point, we need the java sdk
@@ -49,7 +51,6 @@ test:
     # There is an `import attr` in https://github.com/omry/omegaconf/blob/350bdb6/tests/__init__.py#L6 
     # satisfied by `attrs`, added in a later commit in `main`: https://github.com/omry/omegaconf/commit/a0cc301
     - attrs
-    # Temporary pin <https://github.com/conda-forge/omegaconf-feedstock/pull/40#issuecomment-1294669062>
   source_files:
     - tests
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,6 @@ requirements:
     - python
     - pyyaml >=5.1.0
     - antlr4-python3-runtime 4.9
-    - typing_extensions
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,23 +6,34 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/omegaconf-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
-    - antlr 4.9
+    #
+    # antlr is included as binary in build_helpers/bin/antlr-4.9.3-complete.jar
+    # also for this reason and the next point, we need the java sdk
+    # https://github.com/omry/omegaconf/blob/fd73050/build_helpers/build_helpers.py#L33
+    # in future versions it will be included in the vendor folder, see open PR: https://github.com/omry/omegaconf/pull/1114
+    # 
+    # - antlr 4.9
+    #
+    # in setup.py there is an ANTLRCommand import
+    # https://github.com/omry/omegaconf/blob/350bdb632865c5dd2286f2f6521acefe4abd843d/setup.py#L16-L23
+    # which is a command run using java, therefore java jdk is needed
+    # https://github.com/omry/omegaconf/blob/fd73050/build_helpers/build_helpers.py#L30-L40
+    - openjdk
   run:
-    - python >=3.7
+    - python
     - pyyaml >=5.1.0
-    - antlr-python-runtime 4.9
+    - antlr4-python3-runtime 4.9
     - typing_extensions
 
 test:
@@ -34,6 +45,7 @@ test:
     - pytest-mock
     - pytest-lazy-fixture
     - pip
+    - attrs
     # Temporary pin <https://github.com/conda-forge/omegaconf-feedstock/pull/40#issuecomment-1294669062>
   source_files:
     - tests
@@ -47,7 +59,6 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: Flexible python configuration system
-
   description: |
     OmegaConf is a hierarchical configuration system, with support for merging
     configurations from multiple sources (YAML config files,

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  # skip s390x because openjdk is not available
+  skip: true  # [s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
@@ -45,6 +47,8 @@ test:
     - pytest-mock
     - pytest-lazy-fixture
     - pip
+    # There is an `import attr` in https://github.com/omry/omegaconf/blob/350bdb6/tests/__init__.py#L6 
+    # satisfied by `attrs`, added in a later commit in `main`: https://github.com/omry/omegaconf/commit/a0cc301
     - attrs
     # Temporary pin <https://github.com/conda-forge/omegaconf-feedstock/pull/40#issuecomment-1294669062>
   source_files:


### PR DESCRIPTION
[PKG-3353] omegaconf 2.3.0 ❄️

- upstream: https://github.com/omry/omegaconf/tree/v2.3.0 
- dependency files:
    - https://github.com/omry/omegaconf/blob/v2.3.0/requirements/base.txt
    - Tests: see comment below about `attrs`
- conda-forge: https://github.com/conda-forge/omegaconf-feedstock 
    
**Destination channel:** Snowflake

**Changes**
- There is an `import attr` in https://github.com/omry/omegaconf/blob/350bdb632865c5dd2286f2f6521acefe4abd843d/tests/__init__.py#L6 satisfied by `attrs`, added in a later commit in `main`: https://github.com/omry/omegaconf/commit/a0cc301feee4962c7da884724d057205dd338993
- It requires the openjdk dependency, have a look at:
    - https://github.com/omry/omegaconf/blob/v2.3.0/build_helpers/build_helpers.py 
    - https://github.com/omry/omegaconf/blob/350bdb632865c5dd2286f2f6521acefe4abd843d/setup.py#L16-L23


**Depends on**
- AnacondaRecipes/pytest-lazy-fixture-feedstock#2

**Dependency for**
- kedro v0.18.14 ❄️


[PKG-3353]: https://anaconda.atlassian.net/browse/PKG-3353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ